### PR TITLE
add child ref

### DIFF
--- a/lib/responsiveHOC.js
+++ b/lib/responsiveHOC.js
@@ -54,7 +54,7 @@ function responsiveHOC() {
       }, {
         key: 'render',
         value: function render() {
-          return React.createElement(Component, _extends({}, this.props, this.state));
+          return React.createElement(Component, _extends({ ref: 'lineEllipsisChild' }, this.props, this.state));
         }
       }]);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-lines-ellipsis",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Simple multiline ellipsis component for React.JS",
   "main": "lib/index.js",
   "files": [

--- a/src/responsiveHOC.js
+++ b/src/responsiveHOC.js
@@ -28,7 +28,7 @@ function responsiveHOC (wait = 150, debounceOptions) {
       }
 
       render () {
-        return <Component {...this.props} {...this.state} />
+        return <Component ref='lineEllipsisChild' {...this.props} {...this.state} />
       }
     }
 


### PR DESCRIPTION
with the new responsiveHOC there is no ability to get the state of the inner child via ref.