### PR TITLE
Fix a bug where ndPrevUnit could be undefined

### DIFF
--- a/lib/html.js
+++ b/lib/html.js
@@ -188,7 +188,7 @@ var HTMLEllipsis = function (_React$PureComponent) {
       var ndEllipsis = this.makeEllipsisSpan();
       findBlockAncestor(ndPrevUnit).appendChild(ndEllipsis);
 
-      while (ndPrevUnit && (!affectLayout(ndPrevUnit) || ndEllipsis.offsetHeight > ndPrevUnit.offsetHeight || ndEllipsis.offsetTop > ndPrevUnit.offsetTop)) {
+      while (this.nlUnits.length && (!affectLayout(ndPrevUnit) || ndEllipsis.offsetHeight > ndPrevUnit.offsetHeight || ndEllipsis.offsetTop > ndPrevUnit.offsetTop)) {
         ndPrevUnit = this.nlUnits.pop();
         removeFollowingElementLeaves(ndPrevUnit, this.canvas);
         findBlockAncestor(ndPrevUnit).appendChild(ndEllipsis);

--- a/src/html.js
+++ b/src/html.js
@@ -160,7 +160,7 @@ class HTMLEllipsis extends React.PureComponent {
     const ndEllipsis = this.makeEllipsisSpan()
     findBlockAncestor(ndPrevUnit).appendChild(ndEllipsis)
 
-    while (ndPrevUnit && (
+    while (this.nlUnits.length && (
       !affectLayout(ndPrevUnit) ||
       ndEllipsis.offsetHeight > ndPrevUnit.offsetHeight ||
       ndEllipsis.offsetTop > ndPrevUnit.offsetTop)


### PR DESCRIPTION
Inside `putEllipsis`, checking that `ndPrevUnit` is truthy doesn't do anything, because the line immediately after the check does `ndPrevUnit = this.nlUnits.pop();`, which will sometimes set `ndPrevUnit` to `undefined`.