### PR TITLE
Fix wrong priority for basedOn

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -12,6 +12,6 @@ module.exports = {
     border: 'none'
   },
 
-  mirrorProps: ['box-sizing', 'width', 'font-size', 'font-weight', 'font-family', 'font-style', 'letter-spacing', 'text-indent', 'white-space', 'word-break', 'padding-left', 'padding-right']
+  mirrorProps: ['box-sizing', 'width', 'font-size', 'font-weight', 'font-family', 'font-style', 'letter-spacing', 'text-indent', 'white-space', 'word-break', 'padding-left', 'padding-right', 'word-break', 'overflow-wrap']
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -93,7 +93,7 @@ var LinesEllipsis = function (_React$PureComponent) {
     key: 'reflow',
     value: function reflow(props) {
       /* eslint-disable no-control-regex */
-      var basedOn = props.basedOn || /^[\x00-\x7F]+$/.test(props.text) ? 'words' : 'letters';
+      var basedOn = props.basedOn || (/^[\x00-\x7F]+$/.test(props.text) ? 'words' : 'letters');
       switch (basedOn) {
         case 'words':
           this.units = props.text.split(/\b|(?=\W)/);

--- a/src/common.js
+++ b/src/common.js
@@ -12,7 +12,6 @@ module.exports = {
 
   mirrorProps: [
     'box-sizing',
-    'width',
     'font-size',
     'font-weight',
     'font-family',

--- a/src/common.js
+++ b/src/common.js
@@ -22,6 +22,8 @@ module.exports = {
     'white-space',
     'word-break',
     'padding-left',
-    'padding-right'
+    'padding-right',
+    'word-break',
+    'overflow-wrap'
   ]
 }

--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,7 @@ class LinesEllipsis extends React.PureComponent {
 
   reflow (props) {
     /* eslint-disable no-control-regex */
-    const basedOn = props.basedOn || /^[\x00-\x7F]+$/.test(props.text) ? 'words' : 'letters'
+    const basedOn = props.basedOn || (/^[\x00-\x7F]+$/.test(props.text) ? 'words' : 'letters')
     switch (basedOn) {
       case 'words':
         this.units = props.text.split(/\b|(?=\W)/)

--- a/src/index.js
+++ b/src/index.js
@@ -60,6 +60,7 @@ class LinesEllipsis extends React.PureComponent {
     mirrorProps.forEach((key) => {
       this.canvas.style[key] = targetStyle[key]
     })
+    this.canvas.style.width = this.target.clientWidth + 'px'
   }
 
   reflow (props) {


### PR DESCRIPTION
`props.basedOn || /^[\x00-\x7F]+$/.test(props.text) ? 'words' : 'letters'` is calculated as `(props.basedOn || /^[\x00-\x7F]+$/.test(props.text)) ? 'words' : 'letters'`