### PR TITLE
Pass rest props to rendering component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# Yarn lock file
+yarn.lock

--- a/lib/html.js
+++ b/lib/html.js
@@ -1,6 +1,10 @@
 'use strict';
 
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -229,19 +233,23 @@ var HTMLEllipsis = function (_React$PureComponent) {
       var _state = this.state,
           html = _state.html,
           clamped = _state.clamped;
+
       var _props = this.props,
           Component = _props.component,
           className = _props.className,
-          unsafeHTML = _props.unsafeHTML;
+          unsafeHTML = _props.unsafeHTML,
+          maxLine = _props.maxLine,
+          ellipsis = _props.ellipsis,
+          rest = _objectWithoutProperties(_props, ['component', 'className', 'unsafeHTML', 'maxLine', 'ellipsis']);
 
       return React.createElement(
         Component,
-        {
+        _extends({
           className: 'LinesEllipsis ' + (clamped ? 'LinesEllipsis--clamped' : '') + ' ' + className,
           ref: function ref(node) {
             return _this3.target = node;
           }
-        },
+        }, rest),
         React.createElement('div', { dangerouslySetInnerHTML: { __html: clamped ? html : unsafeHTML } })
       );
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,10 @@
 'use strict';
 
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -175,20 +179,24 @@ var LinesEllipsis = function (_React$PureComponent) {
       var _state = this.state,
           text = _state.text,
           clamped = _state.clamped;
+
       var _props = this.props,
           Component = _props.component,
           ellipsis = _props.ellipsis,
           trimRight = _props.trimRight,
-          className = _props.className;
+          className = _props.className,
+          propText = _props.text,
+          maxLine = _props.maxLine,
+          rest = _objectWithoutProperties(_props, ['component', 'ellipsis', 'trimRight', 'className', 'text', 'maxLine']);
 
       return React.createElement(
         Component,
-        {
+        _extends({
           className: 'LinesEllipsis ' + (clamped ? 'LinesEllipsis--clamped' : '') + ' ' + className,
           ref: function ref(node) {
             return _this3.target = node;
           }
-        },
+        }, rest),
         clamped && trimRight ? text.replace(/[\s\uFEFF\xA0]+$/, '') : text,
         React.createElement('wbr', null),
         clamped && React.createElement(

--- a/src/html.js
+++ b/src/html.js
@@ -196,11 +196,12 @@ class HTMLEllipsis extends React.PureComponent {
 
   render () {
     const {html, clamped} = this.state
-    const {component: Component, className, unsafeHTML} = this.props
+    const {component: Component, className, unsafeHTML, maxLine, ellipsis, ...rest} = this.props
     return (
       <Component
         className={`LinesEllipsis ${clamped ? 'LinesEllipsis--clamped' : ''} ${className}`}
         ref={node => (this.target = node)}
+        {...rest}
       >
         <div dangerouslySetInnerHTML={{__html: clamped ? html : unsafeHTML}} />
       </Component>

--- a/src/index.js
+++ b/src/index.js
@@ -141,11 +141,12 @@ class LinesEllipsis extends React.PureComponent {
 
   render () {
     const {text, clamped} = this.state
-    const {component: Component, ellipsis, trimRight, className} = this.props
+    const {component: Component, ellipsis, trimRight, className, text: propText, maxLine, ...rest} = this.props
     return (
       <Component
         className={`LinesEllipsis ${clamped ? 'LinesEllipsis--clamped' : ''} ${className}`}
         ref={node => (this.target = node)}
+        {...rest}
       >
         {clamped && trimRight
           ? text.replace(/[\s\uFEFF\xA0]+$/, '')


### PR DESCRIPTION
Issue: Rendering component should extra props like `title` and `aria` attributes.
Fix: Pass the unused props to rendering component using spread operator.