### PR TITLE
Add ellipsesHTML prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ import LinesEllipsis from 'react-lines-ellipsis'
   text='long long text'
   maxLine='3'
   ellipsis='...'
+  ellipsesHTML='...' // Note that ellipsesHTML will supercede ellipses if passed
   trimRight
   basedOn='letters'
 />
@@ -42,6 +43,10 @@ Max count of lines allowed. Default `1`.
 ### props.ellipsis {String}
 
 Text content of the ellipsis. Default `…`.
+
+### props.ellipsisHTML {String}
+
+HTML content of the ellipsis.
 
 ### props.trimRight {Boolean}
 

--- a/lib/html.js
+++ b/lib/html.js
@@ -213,7 +213,11 @@ var HTMLEllipsis = function (_React$PureComponent) {
       frag.appendChild(document.createElement('wbr'));
       var ndEllipsis = document.createElement('span');
       ndEllipsis.className = 'LinesEllipsis-ellipsis';
-      ndEllipsis.textContent = this.props.ellipsis;
+      if (this.props.ellipsisHTML) {
+        ndEllipsis.innerHTML = this.props.ellipsisHTML;
+      } else {
+        ndEllipsis.textContent = this.props.ellipsis;
+      }
       frag.appendChild(ndEllipsis);
       return frag;
     }
@@ -240,8 +244,11 @@ var HTMLEllipsis = function (_React$PureComponent) {
           unsafeHTML = _props.unsafeHTML,
           maxLine = _props.maxLine,
           ellipsis = _props.ellipsis,
+          ellipsisHTML = _props.ellipsisHTML,
+          trimRight = _props.trimRight,
+          winWidth = _props.winWidth,
           basedOn = _props.basedOn,
-          rest = _objectWithoutProperties(_props, ['component', 'className', 'unsafeHTML', 'maxLine', 'ellipsis', 'basedOn']);
+          rest = _objectWithoutProperties(_props, ['component', 'className', 'unsafeHTML', 'maxLine', 'ellipsis', 'ellipsisHTML', 'trimRight', 'winWidth', 'basedOn']);
 
       return React.createElement(
         Component,

--- a/src/html.js
+++ b/src/html.js
@@ -184,7 +184,11 @@ class HTMLEllipsis extends React.PureComponent {
     frag.appendChild(document.createElement('wbr'))
     const ndEllipsis = document.createElement('span')
     ndEllipsis.className = 'LinesEllipsis-ellipsis'
-    ndEllipsis.textContent = this.props.ellipsis
+    if (this.props.ellipsisHTML) {
+      ndEllipsis.innerHTML = this.props.ellipsisHTML
+    } else {
+      ndEllipsis.textContent = this.props.ellipsis
+    }
     frag.appendChild(ndEllipsis)
     return frag
   }
@@ -196,7 +200,9 @@ class HTMLEllipsis extends React.PureComponent {
 
   render () {
     const {html, clamped} = this.state
-    const {component: Component, className, unsafeHTML, maxLine, ellipsis, basedOn, ...rest} = this.props
+    const {component: Component, className, unsafeHTML, maxLine, ellipsis,
+           ellipsisHTML, trimRight, winWidth, basedOn, ...rest} = this.props
+
     return (
       <Component
         className={`LinesEllipsis ${clamped ? 'LinesEllipsis--clamped' : ''} ${className}`}


### PR DESCRIPTION
Adds the ability to pass an `ellipsesHTML` prop for rendering html content. Useful for customizing the "read more" link. Also removes `trimRight` and `winWidth` (responsiveHOC) from passed props to `div` as it was throwing error warning from react.