### PR TITLE
onTruncate callback prop

### DIFF
--- a/lib/html.js
+++ b/lib/html.js
@@ -90,7 +90,8 @@ var defaultProps = {
   ellipsisHTML: undefined,
   className: '',
   basedOn: undefined,
-  winWidth: undefined // for the HOC
+  winWidth: undefined, // for the HOC
+  onTruncate: undefined
 };
 var usedProps = Object.keys(defaultProps);
 
@@ -173,6 +174,9 @@ var HTMLEllipsis = function (_React$PureComponent) {
       this.setState({ clamped: clamped });
       if (clamped) {
         this.setState({ html: this.canvas.innerHTML });
+      }
+      if (this.props.onTruncate) {
+        this.props.onTruncate(clamped);
       }
     }
   }, {

--- a/src/html.js
+++ b/src/html.js
@@ -74,7 +74,8 @@ const defaultProps = {
   ellipsisHTML: undefined,
   className: '',
   basedOn: undefined,
-  winWidth: undefined // for the HOC
+  winWidth: undefined, // for the HOC
+  onTruncate: undefined
 }
 const usedProps = Object.keys(defaultProps)
 
@@ -141,6 +142,9 @@ class HTMLEllipsis extends React.PureComponent {
     this.setState({clamped})
     if (clamped) {
       this.setState({html: this.canvas.innerHTML})
+    }
+    if (this.props.onTruncate) {
+      this.props.onTruncate(clamped)
     }
   }
 


### PR DESCRIPTION
Hi Xiaody,

We've been using this ellipsis library, it's great.

We have just had one problem.

We need to know when the `reflow()` method has ran, and then if the text has been clamped (for rendering a ReadMore button).

In Issue #21 you mentioned the method `isClamped` but as `reflow` is only called on `componentDidMount()` we can't just check this in another component's `render()` method

I have added an onTruncate callback prop in this PR.

Please let me know what you think.

Cheers,
Dan
