### PR TITLE
[responsiveHOC] Don’t call setState on unmounted component.

### DIFF
--- a/lib/responsiveHOC.js
+++ b/lib/responsiveHOC.js
@@ -32,6 +32,7 @@ function responsiveHOC() {
         _this.state = {
           winWidth: isBrowser ? window.innerWidth : 0
         };
+        _this._isMounted = false;
         _this.onResize = debounce(_this.onResize.bind(_this), wait, debounceOptions);
         return _this;
       }
@@ -39,19 +40,23 @@ function responsiveHOC() {
       _createClass(Responsive, [{
         key: 'componentDidMount',
         value: function componentDidMount() {
+          this._isMounted = true;
           window.addEventListener('resize', this.onResize);
         }
       }, {
         key: 'componentWillUnmount',
         value: function componentWillUnmount() {
+          this._isMounted = false;
           window.removeEventListener('resize', this.onResize);
         }
       }, {
         key: 'onResize',
         value: function onResize() {
-          this.setState({
-            winWidth: window.innerWidth
-          });
+          if (this._isMounted) {
+            this.setState({
+              winWidth: window.innerWidth
+            });
+          }
         }
       }, {
         key: 'render',

--- a/src/responsiveHOC.js
+++ b/src/responsiveHOC.js
@@ -10,21 +10,26 @@ function responsiveHOC (wait = 150, debounceOptions) {
         this.state = {
           winWidth: isBrowser ? window.innerWidth : 0
         }
+        this._isMounted = false
         this.onResize = debounce(this.onResize.bind(this), wait, debounceOptions)
       }
 
       componentDidMount () {
+        this._isMounted = true
         window.addEventListener('resize', this.onResize)
       }
 
       componentWillUnmount () {
+        this._isMounted = false
         window.removeEventListener('resize', this.onResize)
       }
 
       onResize () {
-        this.setState({
-          winWidth: window.innerWidth
-        })
+        if (this._isMounted) {
+          this.setState({
+            winWidth: window.innerWidth
+          })
+        }
       }
 
       render () {


### PR DESCRIPTION
Due to debouncing the `onResize` callback gets triggered later than expected, resulting in this bug.