### PR TITLE
Fix/Selectively Call Reflow on Component Update

### DIFF
--- a/lib/html.js
+++ b/lib/html.js
@@ -162,7 +162,7 @@ function (_React$Component) {
         this.copyStyleToCanvas();
       }
 
-      if (this.props !== prevProps) {
+      if (!_.isEqual(this.props, prevProps)) {
         this.reflow(this.props);
       }
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -102,7 +102,7 @@ function (_React$Component) {
         this.copyStyleToCanvas();
       }
 
-      if (this.props !== prevProps) {
+      if (!_.isEqual(this.props, prevProps)) {
         this.reflow(this.props);
       }
     }

--- a/src/html.js
+++ b/src/html.js
@@ -107,7 +107,7 @@ class HTMLEllipsis extends React.Component {
     if (prevProps.winWidth !== this.props.winWidth) {
       this.copyStyleToCanvas()
     }
-    if (this.props !== prevProps) {
+    if (!_.isEqual(this.props, prevProps)) {
       this.reflow(this.props)
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -50,7 +50,7 @@ class LinesEllipsis extends React.Component {
     if (prevProps.winWidth !== this.props.winWidth) {
       this.copyStyleToCanvas()
     }
-    if (this.props !== prevProps) {
+    if (!_.isEqual(this.props, prevProps)) {
       this.reflow(this.props)
     }
   }


### PR DESCRIPTION
Since the reference equality check to compare previous `props` with the new `props` fails when new props are passed in that have the same values as the previous props, `reflow` was getting called every time the component re-rendered, leading to a huge performance hit.

By using LoDash's deep object equality comparison, we're able to eliminate unnecessary calls to `reflow` that are getting made when `props` hasn't changed.

Performance improvement:
On a page with 48 LinesEllipsis components already rendered, when I update the page to render an additional 24 `LinesEllipses` components:

- With this PR: This takes ~2.5 seconds
- Without this PR: This takes ~21 seconds