### PR TITLE
Fix crash when using Safari Translation feature

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -56,8 +56,10 @@ class LinesEllipsis extends React.Component {
   }
 
   componentWillUnmount () {
-    this.canvas.parentNode.removeChild(this.canvas)
-    this.canvas = null
+    if (this.canvas) {
+      this.canvas.parentNode.removeChild(this.canvas)
+      this.canvas = null
+    }
   }
 
   setState (state, callback) {


### PR DESCRIPTION
# Summary

This PR is to address an issue where the app would crash (unhandled exception is thrown) in Safari, when the following is true:
- Safari's translation feature is enabled
- at least one `LinesEllipsis` with and one without truncated text is first rendered on the screen and then unmounted

## Steps to reproduce
- Render 2 `LinesEllipsis` components on the screen; 1 should truncate the text and one should not
  - in my case I set `basedOn="letters"` but I *think* that doesn't really play a role
- Open the page in Safari (mobile/desktop doesn't matter)
- Translate the page to something other than what the original language was; make sure that the text inside `LinesEllipsis` gets translated
- unmount the components
- 💥 

## Minimal reproducible example

https://github.com/zigcccc/react-lines-ellipsis-crash-minimal-reproducible-example

## Demo
https://github.com/xiaody/react-lines-ellipsis/assets/14889659/b2d5dfd4-d61f-4d4d-bc23-cf5adbaa88a7

## The problem
- for some reason, when Safari applies translations, it manipulates DOM nodes in a way to trigger `this.canvas` to be `null`
- in `componentWillUnmount`, we're assuming that `this.canvas` is always defined
- since that's not the case, we're accessing property (`parentNode`) on `null`, which causes the crash

<img width="749" alt="image" src="https://github.com/xiaody/react-lines-ellipsis/assets/14889659/dc829b65-41ee-460e-8212-1a59212e265b">

I'm not sure how exactly that happens, and why this is scoped to Safari only (applying translations in Chrome works without any issues). But simply verifying that we have a canvas element to work with before doing any operations on it prevents the app from crashing, which is the goal of this PR.
