### PR TITLE
Replace usage of defaultProps

### DIFF
--- a/src/html.jsx
+++ b/src/html.jsx
@@ -89,6 +89,7 @@ const usedProps = Object.keys(defaultProps)
 class HTMLEllipsis extends React.Component {
   constructor (props) {
     super(props)
+    this.props = { ...defaultProps, ...props }
     this.state = {
       html: props.unsafeHTML,
       clamped: false
@@ -239,7 +240,5 @@ class HTMLEllipsis extends React.Component {
     )
   }
 }
-
-HTMLEllipsis.defaultProps = defaultProps
 
 export default HTMLEllipsis

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -32,6 +32,7 @@ const usedProps = Object.keys(defaultProps)
 class LinesEllipsis extends React.Component {
   constructor (props) {
     super(props)
+    this.props = { ...defaultProps, ...props }
     this.state = {
       text: props.text,
       clamped: false
@@ -184,7 +185,5 @@ class LinesEllipsis extends React.Component {
     )
   }
 }
-
-LinesEllipsis.defaultProps = defaultProps
 
 export default LinesEllipsis

--- a/src/loose.jsx
+++ b/src/loose.jsx
@@ -1,7 +1,14 @@
 import React from 'react'
 
-function LinesEllipsisLoose (props) {
-  const { component: Component, text, lineHeight, maxLine, style, overflowFallback, ...rest } = props
+function LinesEllipsisLoose ({
+  component: Component = 'div',
+  text,
+  lineHeight,
+  maxLine = 1,
+  style = {},
+  overflowFallback = true,
+  ...rest
+}) {
   const maxLineNumber = +maxLine || 1
   let usedStyle = {
     ...style,
@@ -26,13 +33,6 @@ function LinesEllipsisLoose (props) {
       {text}
     </Component>
   )
-}
-
-LinesEllipsisLoose.defaultProps = {
-  component: 'div',
-  maxLine: 1,
-  style: {},
-  overflowFallback: true
 }
 
 export default LinesEllipsisLoose

--- a/src/responsiveHOC.jsx
+++ b/src/responsiveHOC.jsx
@@ -2,11 +2,16 @@ import React from 'react'
 import debounce from 'lodash/debounce'
 const isBrowser = typeof window !== 'undefined'
 
+const defaultProps = {
+  innerRef: () => {}
+}
+
 export default function responsiveHOC (wait = 150, debounceOptions) {
   return Component => {
     class Responsive extends React.Component {
       constructor (props) {
         super(props)
+        this.props = { ...defaultProps, ...props }
         this.state = {
           winWidth: isBrowser ? window.innerWidth : 0
         }
@@ -35,9 +40,7 @@ export default function responsiveHOC (wait = 150, debounceOptions) {
     }
 
     Responsive.displayName = `Responsive(${Component.displayName || Component.name})`
-    Responsive.defaultProps = {
-      innerRef () {}
-    }
+
     return Responsive
   }
 }


### PR DESCRIPTION
Replace usage of defaultProps. This is deprecated and will be removed in future React versions (see [facebook/react#16210](https://github.com/facebook/react/pull/16210))

Here is the current warning
```...: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead```